### PR TITLE
Playnote uses volume from vm to set gain

### DIFF
--- a/src/InstrumentPlayer.js
+++ b/src/InstrumentPlayer.js
@@ -35,11 +35,15 @@ function InstrumentPlayer (outputNode) {
  * @param  {number} sec - a duration in seconds
  * @param  {number} instrumentNum - an instrument number (0-indexed)
  */
-InstrumentPlayer.prototype.playNoteForSecWithInst = function (note, sec, instrumentNum) {
+InstrumentPlayer.prototype.playNoteForSecWithInstAndVol = function (note, sec, instrumentNum, vol) {
+    var gain = vol / 100;
     this.loadInstrument(instrumentNum)
         .then(() => {
             this.instruments[instrumentNum].play(
-                note, Tone.context.currentTime, {duration : sec}
+                note, Tone.context.currentTime, {
+                    duration : sec,
+                    gain : gain
+                }
             );
         });
 };

--- a/src/InstrumentPlayer.js
+++ b/src/InstrumentPlayer.js
@@ -34,6 +34,7 @@ function InstrumentPlayer (outputNode) {
  * @param  {number} note - a MIDI note number
  * @param  {number} sec - a duration in seconds
  * @param  {number} instrumentNum - an instrument number (0-indexed)
+ * @param  {number} vol - a volume level (0-100%)
  */
 InstrumentPlayer.prototype.playNoteForSecWithInstAndVol = function (note, sec, instrumentNum, vol) {
     var gain = vol / 100;

--- a/src/index.js
+++ b/src/index.js
@@ -91,10 +91,11 @@ AudioEngine.prototype.loadSounds = function (sounds) {
 };
 
 /**
- * Play a note for a duration on an instrument
+ * Play a note for a duration on an instrument with a volume
  * @param  {number} note - a MIDI note number
  * @param  {number} beats - a duration in beats
  * @param  {number} inst - an instrument number (0-indexed)
+ * @param  {number} vol - a volume level (0-100%)
  * @return {Promise} a Promise that resolves after the duration has elapsed
  */
 AudioEngine.prototype.playNoteForBeatsWithInstAndVol = function (note, beats, inst, vol) {

--- a/src/index.js
+++ b/src/index.js
@@ -97,9 +97,9 @@ AudioEngine.prototype.loadSounds = function (sounds) {
  * @param  {number} inst - an instrument number (0-indexed)
  * @return {Promise} a Promise that resolves after the duration has elapsed
  */
-AudioEngine.prototype.playNoteForBeatsWithInst = function (note, beats, inst) {
+AudioEngine.prototype.playNoteForBeatsWithInstAndVol = function (note, beats, inst, vol) {
     var sec = this.beatsToSec(beats);
-    this.instrumentPlayer.playNoteForSecWithInst(note, sec, inst);
+    this.instrumentPlayer.playNoteForSecWithInstAndVol(note, sec, inst, vol);
     return this.waitForBeats(beats);
 };
 


### PR DESCRIPTION
### Resolves

Addresses https://github.com/LLK/scratch-vm/issues/404

Depends on https://github.com/LLK/scratch-vm/pull/444

### Proposed changes

The AudioEngine has a function which requests the InstrumentPlayer to play notes. This function now takes a volume argument, and passes it to the InstrumentPlayer, which uses that to set the gain of the note it plays. 

### Reason for changes

This is a workaround for the current temporary version of InstrumentPlayer to enable the volume setting to affect notes played with play note blocks. Note that this is a slightly different behavior than the effect of setting volume on play sound and play drum: in this case, the volume is applied at the start of the note, and applies to its whole duration, while for other sounds, the volume change takes effect immediately.