### PR TITLE
Offer unpacked code from package.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly specify line endings for as many files as possible.
+# People who (for example) rsync between Windows and Linux need this.
+
+# File types which we know are binary
+*.wav binary
+
+# Prefer LF for most file types
+*.js text eol=lf
+*.js.map text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.txt text eol=lf
+
+# Prefer LF for these files
+.editorconfig text eol=lf
+.eslintignore text eol=lf
+.eslintrc text eol=lf
+.gitattributes text eol=lf
+.gitignore text eol=lf
+.npmignore text eol=lf
+LICENSE text eol=lf
+
+# Use CRLF for Windows-specific file types

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '4.2'
-- 'stable'
+- '6'
+- 'node'
 cache:
   directories:
   - node_modules

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "scratch-audio",
   "version": "0.1.0",
   "description": "audio engine for scratch 3.0",
-  "main": "dist.js",
+  "main": "./src/index.js",
   "scripts": {
     "test": "npm run lint && npm run build",
     "build": "webpack --bail",
@@ -20,6 +20,11 @@
     "url": "https://github.com/LLK/scratch-audio/issues"
   },
   "homepage": "https://github.com/LLK/scratch-audio#readme",
+  "dependencies": {
+    "minilog": "^3.0.1",
+    "soundfont-player": "0.10.5",
+    "tone": "0.8.0"
+  },
   "devDependencies": {
     "babel-core": "6.17.0",
     "babel-eslint": "7.0.0",
@@ -27,11 +32,7 @@
     "babel-preset-es2015": "6.16.0",
     "eslint": "3.7.1",
     "json": "9.0.4",
-    "minilog": "^3.0.1",
-    "soundfont-player": "0.10.5",
-    "tone": "0.8.0",
     "travis-after-all": "1.4.4",
     "webpack": "1.13.2"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
### Proposed Changes

This change declares `./src/index.js` as the "main" script in `package.json`. We still build `dist.js` in case we want to use it directly as part of a web page, perhaps for debugging.

### Reason for Changes

This sets us up to build `scratch-gui` in a single step, allowing webpack to better optimize our files and reducing the duplication of code within our output bundles.

### Test Coverage

Test coverage has not changed.
