### PR TITLE
Use scratch storage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ var EchoEffect = require('./effects/EchoEffect');
 var ReverbEffect = require('./effects/ReverbEffect');
 
 var SoundPlayer = require('./SoundPlayer');
-var ADPCMSoundLoader = require('./ADPCMSoundLoader');
+var ADPCMSoundDecoder = require('./ADPCMSoundDecoder');
 var InstrumentPlayer = require('./InstrumentPlayer');
 var DrumPlayer = require('./DrumPlayer');
 

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,14 @@ AudioEngine.prototype.decodeSound = function (sound) {
     );
 };
 
-
+/**
+ * An older version of the AudioEngine had this function to load all sounds
+ * This is a stub to provide a warning when it is called
+ * @todo remove this
+ */
+AudioEngine.prototype.loadSounds = function () {
+    log.warn('The loadSounds function is no longer available. Please use Scratch Storage.');
+};
 
 /**
  * Play a note for a duration on an instrument with a volume


### PR DESCRIPTION
### Proposed changes

Previously, the audio engine downloaded and decoded all the sounds for a rendered target. Now, it only decodes individual sounds on request from the VM.

### Reason for changes

Scratch-storage now handles downloading sounds.