### PR TITLE
Return the loader promise for chaining

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,10 @@ function AudioEngine () {
  * Decode a sound, decompressing it into audio samples.
  * Store a reference to it the sound in the audioBuffers dictionary, indexed by md5
  * @param  {Object} sound - an object containing audio data and metadata for a sound
+ * @property {Buffer} data - sound data loaded from scratch-storage.
+ * @property {string} format - format type, either empty or adpcm.
+ * @property {string} md5 - the MD5 and extension of the sound.
+ * @returns {?Promise} - a promise which will resolve after the audio buffer is stored, or null on error.
  */
 AudioEngine.prototype.decodeSound = function (sound) {
 

--- a/src/index.js
+++ b/src/index.js
@@ -76,8 +76,7 @@ AudioEngine.prototype.decodeSound = function (sound) {
     }
 
     var storedContext = this;
-
-    loaderPromise.then(
+    return loaderPromise.then(
         function (decodedAudio) {
             storedContext.audioBuffers[sound.md5] = new Tone.Buffer(decodedAudio);
         },
@@ -319,4 +318,3 @@ AudioPlayer.prototype.setVolume = function (value) {
 };
 
 module.exports = AudioEngine;
-


### PR DESCRIPTION
This PR makes the `decodeSound` function return the loader promise so that other things can chain to the decoded call (for example, the sound library loading sounds on demand and then playing them).