### PR TITLE
Use native audio buffer source node

### DIFF
--- a/src/SoundPlayer.js
+++ b/src/SoundPlayer.js
@@ -60,7 +60,8 @@ class SoundPlayer {
             return;
         }
 
-        this.bufferSource = new Tone.BufferSource(this.buffer.get());
+        this.bufferSource = Tone.context.createBufferSource();
+        this.bufferSource.buffer = this.buffer.get();
         this.bufferSource.playbackRate.value = this.playbackRate;
         this.bufferSource.connect(this.outputNode);
         this.bufferSource.start();


### PR DESCRIPTION
### Proposed changes

Switch to using the native audio buffer source node, instead of the Tone js wrapper for it. This is because a recent update to Tone changed the ‘onended’ callback in a way that broke our “play sound until done” block.

### Reason for changes

Resolves https://github.com/LLK/scratch-audio/issues/38