### PR TITLE
Make a copy before using audio buffer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -232,12 +232,15 @@ class AudioEngine {
 
         let loaderPromise = null;
 
+        // Make a copy of the buffer because decoding detaches the original buffer
+        var bufferCopy = sound.data.buffer.slice(0);
+
         switch (sound.format) {
         case '':
-            loaderPromise = Tone.context.decodeAudioData(sound.data.buffer);
+            loaderPromise = Tone.context.decodeAudioData(bufferCopy);
             break;
         case 'adpcm':
-            loaderPromise = (new ADPCMSoundDecoder()).decode(sound.data.buffer);
+            loaderPromise = (new ADPCMSoundDecoder()).decode(bufferCopy);
             break;
         default:
             return log.warn('unknown sound format', sound.format);


### PR DESCRIPTION
### Proposed changes

_Describe what this Pull Request does_
Take a new copy of the array buffer (via `.slice(0)`) before decoding it because decoding is a destructive operation to the array buffer. 

This is in response to https://www.chromestatus.com/feature/5539919174828032 and follows the advice there.

### Reason for changes

_Explain why these changes should be made. Please include an issue # if applicable._

Fixes https://github.com/LLK/scratch-gui/issues/440
