### PR TITLE
Remove tone.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "json": "^9.0.6",
     "minilog": "^3.0.1",
     "soundfont-player": "0.10.5",
-    "tone": "0.9.0",
     "travis-after-all": "^1.4.4",
     "webpack": "2.4.0"
   }

--- a/src/ADPCMSoundDecoder.js
+++ b/src/ADPCMSoundDecoder.js
@@ -1,5 +1,4 @@
 const ArrayBufferStream = require('./ArrayBufferStream');
-const Tone = require('tone');
 const log = require('./log');
 
 /**
@@ -10,6 +9,9 @@ const log = require('./log');
  * https://github.com/LLK/scratch-flash/blob/master/src/sound/WAVFile.as
  */
 class ADPCMSoundDecoder {
+    constructor (context) {
+        this.context = context;
+    }
     /**
      * Data used by the decompression algorithm
      * @type {Array}
@@ -40,7 +42,7 @@ class ADPCMSoundDecoder {
      * Decode an ADPCM sound stored in an ArrayBuffer and return a promise
      * with the decoded audio buffer.
      * @param  {ArrayBuffer} audioData - containing ADPCM encoded wav audio
-     * @return {Tone.Buffer} the decoded audio buffer
+     * @return {AudioBuffer} the decoded audio buffer
      */
     decode (audioData) {
 
@@ -77,8 +79,7 @@ class ADPCMSoundDecoder {
 
             const samples = this.imaDecompress(this.extractChunk('data', stream), this.adpcmBlockSize);
 
-            // @todo this line is the only place Tone is used here, should be possible to remove
-            const buffer = Tone.context.createBuffer(1, samples.length, this.samplesPerSecond);
+            const buffer = this.context.createBuffer(1, samples.length, this.samplesPerSecond);
 
             // @todo optimize this? e.g. replace the divide by storing 1/32768 and multiply?
             for (let i = 0; i < samples.length; i++) {

--- a/src/ADPCMSoundDecoder.js
+++ b/src/ADPCMSoundDecoder.js
@@ -9,8 +9,12 @@ const log = require('./log');
  * https://github.com/LLK/scratch-flash/blob/master/src/sound/WAVFile.as
  */
 class ADPCMSoundDecoder {
-    constructor (context) {
-        this.context = context;
+    /**
+     * @param {AudioContext} audioContext - a webAudio context
+     * @constructor
+     */
+    constructor (audioContext) {
+        this.audioContext = audioContext;
     }
     /**
      * Data used by the decompression algorithm
@@ -79,7 +83,7 @@ class ADPCMSoundDecoder {
 
             const samples = this.imaDecompress(this.extractChunk('data', stream), this.adpcmBlockSize);
 
-            const buffer = this.context.createBuffer(1, samples.length, this.samplesPerSecond);
+            const buffer = this.audioContext.createBuffer(1, samples.length, this.samplesPerSecond);
 
             // @todo optimize this? e.g. replace the divide by storing 1/32768 and multiply?
             for (let i = 0; i < samples.length; i++) {

--- a/src/DrumPlayer.js
+++ b/src/DrumPlayer.js
@@ -38,7 +38,7 @@ class DrumPlayer {
 
             // download and decode the drum sounds
             // @todo: use scratch-storage to manage these sound files
-            const url = baseUrl + fileNames[i] + '_22k.wav';
+            const url = `${baseUrl}${fileNames[i]}_22k.wav`;
             const request = new XMLHttpRequest();
             request.open('GET', url, true);
             request.responseType = 'arraybuffer';

--- a/src/DrumPlayer.js
+++ b/src/DrumPlayer.js
@@ -1,14 +1,13 @@
 const SoundPlayer = require('./SoundPlayer');
-const Tone = require('tone');
 
 class DrumPlayer {
     /**
      * A prototype for the drum sound functionality that can load drum sounds, play, and stop them.
-     * @param {Tone.Gain} outputNode - a webAudio node that the drum sounds will send their output to
+     * @param {AudioContext} context - a webAudio context
      * @constructor
      */
-    constructor (outputNode) {
-        this.outputNode = outputNode;
+    constructor (context) {
+        this.context = context;
 
         const baseUrl = 'https://raw.githubusercontent.com/LLK/scratch-audio/develop/sound-files/drums/';
         const fileNames = [
@@ -35,9 +34,21 @@ class DrumPlayer {
         this.drumSounds = [];
 
         for (let i = 0; i < fileNames.length; i++) {
-            const url = `${baseUrl + fileNames[i]}_22k.wav`;
-            this.drumSounds[i] = new SoundPlayer(this.outputNode);
-            this.drumSounds[i].setBuffer(new Tone.Buffer(url));
+            this.drumSounds[i] = new SoundPlayer(this.context);
+
+            // download and decode the drum sounds
+            // @todo: use scratch-storage to manage these sound files
+            const url = baseUrl + fileNames[i] + '_22k.wav';
+            const request = new XMLHttpRequest();
+            request.open('GET', url, true);
+            request.responseType = 'arraybuffer';
+            request.onload = () => {
+                const audioData = request.response;
+                this.context.decodeAudioData(audioData).then(buffer => {
+                    this.drumSounds[i].setBuffer(buffer);
+                });
+            };
+            request.send();
         }
     }
 
@@ -46,10 +57,10 @@ class DrumPlayer {
      * The parameter for output node allows sprites or clones to send the drum sound
      * to their individual audio effect chains.
      * @param  {number} drum - the drum number to play (0-indexed)
-     * @param  {Tone.Gain} outputNode - a node to send the output to
+     * @param  {AudioNode} outputNode - a node to send the output to
      */
     play (drum, outputNode) {
-        this.drumSounds[drum].outputNode = outputNode;
+        this.drumSounds[drum].connect(outputNode);
         this.drumSounds[drum].start();
     }
 

--- a/src/DrumPlayer.js
+++ b/src/DrumPlayer.js
@@ -3,11 +3,11 @@ const SoundPlayer = require('./SoundPlayer');
 class DrumPlayer {
     /**
      * A prototype for the drum sound functionality that can load drum sounds, play, and stop them.
-     * @param {AudioContext} context - a webAudio context
+     * @param {AudioContext} audioContext - a webAudio context
      * @constructor
      */
-    constructor (context) {
-        this.context = context;
+    constructor (audioContext) {
+        this.audioContext = audioContext;
 
         const baseUrl = 'https://raw.githubusercontent.com/LLK/scratch-audio/develop/sound-files/drums/';
         const fileNames = [
@@ -34,7 +34,7 @@ class DrumPlayer {
         this.drumSounds = [];
 
         for (let i = 0; i < fileNames.length; i++) {
-            this.drumSounds[i] = new SoundPlayer(this.context);
+            this.drumSounds[i] = new SoundPlayer(this.audioContext);
 
             // download and decode the drum sounds
             // @todo: use scratch-storage to manage these sound files
@@ -44,7 +44,7 @@ class DrumPlayer {
             request.responseType = 'arraybuffer';
             request.onload = () => {
                 const audioData = request.response;
-                this.context.decodeAudioData(audioData).then(buffer => {
+                this.audioContext.decodeAudioData(audioData).then(buffer => {
                     this.drumSounds[i].setBuffer(buffer);
                 });
             };

--- a/src/InstrumentPlayer.js
+++ b/src/InstrumentPlayer.js
@@ -1,4 +1,3 @@
-const Tone = require('tone');
 const Soundfont = require('soundfont-player');
 
 class InstrumentPlayer {
@@ -10,11 +9,12 @@ class InstrumentPlayer {
      * play note or set instrument block runs, causing a delay of a few seconds.
      * Using this library we don't have a way to set the volume, sustain the note beyond the sample
      * duration, or run it through the sprite-specific audio effects.
-     * @param {Tone.Gain} outputNode - a webAudio node that the instrument will send its output to
+     * @param {AudioNode} outputNode - a webAudio node that the instrument will send its output to
      * @constructor
      */
-    constructor (outputNode) {
-        this.outputNode = outputNode;
+    constructor (context) {
+        this.context = context;
+        this.outputNode = null;
 
         // Instrument names used by Musyng Kite soundfont, in order to
         // match scratch instruments
@@ -42,7 +42,7 @@ class InstrumentPlayer {
         this.loadInstrument(instrumentNum)
             .then(() => {
                 this.instruments[instrumentNum].play(
-                    note, Tone.context.currentTime, {
+                    note, this.context.currentTime, {
                         duration: sec,
                         gain: gain
                     }
@@ -59,7 +59,7 @@ class InstrumentPlayer {
         if (this.instruments[instrumentNum]) {
             return Promise.resolve();
         }
-        return Soundfont.instrument(Tone.context, this.instrumentNames[instrumentNum])
+        return Soundfont.instrument(this.context, this.instrumentNames[instrumentNum])
                 .then(inst => {
                     inst.connect(this.outputNode);
                     this.instruments[instrumentNum] = inst;

--- a/src/InstrumentPlayer.js
+++ b/src/InstrumentPlayer.js
@@ -9,7 +9,7 @@ class InstrumentPlayer {
      * play note or set instrument block runs, causing a delay of a few seconds.
      * Using this library we don't have a way to set the volume, sustain the note beyond the sample
      * duration, or run it through the sprite-specific audio effects.
-     * @param {AudioNode} outputNode - a webAudio node that the instrument will send its output to
+     * @param {AudioContext} context - a webAudio context
      * @constructor
      */
     constructor (context) {

--- a/src/InstrumentPlayer.js
+++ b/src/InstrumentPlayer.js
@@ -9,11 +9,11 @@ class InstrumentPlayer {
      * play note or set instrument block runs, causing a delay of a few seconds.
      * Using this library we don't have a way to set the volume, sustain the note beyond the sample
      * duration, or run it through the sprite-specific audio effects.
-     * @param {AudioContext} context - a webAudio context
+     * @param {AudioContext} audioContext - a webAudio context
      * @constructor
      */
-    constructor (context) {
-        this.context = context;
+    constructor (audioContext) {
+        this.audioContext = audioContext;
         this.outputNode = null;
 
         // Instrument names used by Musyng Kite soundfont, in order to
@@ -42,7 +42,7 @@ class InstrumentPlayer {
         this.loadInstrument(instrumentNum)
             .then(() => {
                 this.instruments[instrumentNum].play(
-                    note, this.context.currentTime, {
+                    note, this.audioContext.currentTime, {
                         duration: sec,
                         gain: gain
                     }
@@ -59,7 +59,7 @@ class InstrumentPlayer {
         if (this.instruments[instrumentNum]) {
             return Promise.resolve();
         }
-        return Soundfont.instrument(this.context, this.instrumentNames[instrumentNum])
+        return Soundfont.instrument(this.audioContext, this.instrumentNames[instrumentNum])
                 .then(inst => {
                     inst.connect(this.outputNode);
                     this.instruments[instrumentNum] = inst;

--- a/src/SoundPlayer.js
+++ b/src/SoundPlayer.js
@@ -75,12 +75,11 @@ class SoundPlayer {
      * @return {Promise} a Promise that resolves when the sound finishes playing
      */
     finished () {
-        const storedContext = this;
         return new Promise(resolve => {
-            storedContext.bufferSource.onended = function () {
+            this.bufferSource.onended = () => {
                 this.isPlaying = false;
                 resolve();
-            }.bind(storedContext);
+            };
         });
     }
 }

--- a/src/SoundPlayer.js
+++ b/src/SoundPlayer.js
@@ -1,13 +1,13 @@
-const Tone = require('tone');
 const log = require('./log');
 
 /**
  * A SoundPlayer stores an audio buffer, and plays it
  */
 class SoundPlayer {
-    constructor () {
+    constructor (context) {
+        this.context = context;
         this.outputNode = null;
-        this.buffer = new Tone.Buffer();
+        this.buffer = null;
         this.bufferSource = null;
         this.playbackRate = 1;
         this.isPlaying = false;
@@ -15,7 +15,7 @@ class SoundPlayer {
 
     /**
      * Connect the SoundPlayer to an output node
-     * @param  {Tone.Gain} node - an output node to connect to
+     * @param {GainNode} node - an output node to connect to
      */
     connect (node) {
         this.outputNode = node;
@@ -23,7 +23,7 @@ class SoundPlayer {
 
     /**
      * Set an audio buffer
-     * @param {Tone.Buffer} buffer Buffer to set
+     * @param {AudioBuffer} buffer - Buffer to set
      */
     setBuffer (buffer) {
         this.buffer = buffer;
@@ -55,13 +55,13 @@ class SoundPlayer {
      * The web audio framework requires a new audio buffer source node for each playback
      */
     start () {
-        if (!this.buffer || !this.buffer.loaded) {
+        if (!this.buffer) {
             log.warn('tried to play a sound that was not loaded yet');
             return;
         }
 
-        this.bufferSource = Tone.context.createBufferSource();
-        this.bufferSource.buffer = this.buffer.get();
+        this.bufferSource = this.context.createBufferSource();
+        this.bufferSource.buffer = this.buffer;
         this.bufferSource.playbackRate.value = this.playbackRate;
         this.bufferSource.connect(this.outputNode);
         this.bufferSource.start();

--- a/src/SoundPlayer.js
+++ b/src/SoundPlayer.js
@@ -4,8 +4,12 @@ const log = require('./log');
  * A SoundPlayer stores an audio buffer, and plays it
  */
 class SoundPlayer {
-    constructor (context) {
-        this.context = context;
+    /**
+     * @param {AudioContext} audioContext - a webAudio context
+     * @constructor
+     */
+    constructor (audioContext) {
+        this.audioContext = audioContext;
         this.outputNode = null;
         this.buffer = null;
         this.bufferSource = null;
@@ -60,7 +64,7 @@ class SoundPlayer {
             return;
         }
 
-        this.bufferSource = this.context.createBufferSource();
+        this.bufferSource = this.audioContext.createBufferSource();
         this.bufferSource.buffer = this.buffer;
         this.bufferSource.playbackRate.value = this.playbackRate;
         this.bufferSource.connect(this.outputNode);

--- a/src/effects/PanEffect.js
+++ b/src/effects/PanEffect.js
@@ -5,9 +5,13 @@
 * Clamped -100 to 100
 */
 class PanEffect {
-    constructor (context) {
-        this.context = context;
-        this.panner = this.context.createStereoPanner();
+     /**
+     * @param {AudioContext} audioContext - a webAudio context
+     * @constructor
+     */
+    constructor (audioContext) {
+        this.audioContext = audioContext;
+        this.panner = this.audioContext.createStereoPanner();
         this.value = 0;
     }
 

--- a/src/effects/PanEffect.js
+++ b/src/effects/PanEffect.js
@@ -1,17 +1,14 @@
-const Tone = require('tone');
-
 /**
 * A pan effect, which moves the sound to the left or right between the speakers
 * Effect value of -100 puts the audio entirely on the left channel,
 * 0 centers it, 100 puts it on the right.
 * Clamped -100 to 100
 */
-class PanEffect extends Tone.Effect {
-    constructor () {
-        super();
+class PanEffect {
+    constructor (context) {
+        this.context = context;
+        this.panner = this.context.createStereoPanner();
         this.value = 0;
-        this.panner = new Tone.Panner();
-        this.effectSend.chain(this.panner, this.effectReturn);
     }
 
     /**
@@ -21,6 +18,10 @@ class PanEffect extends Tone.Effect {
     set (val) {
         this.value = this.clamp(val, -100, 100);
         this.panner.pan.value = this.value / 100;
+    }
+
+    connect (node) {
+        this.panner.connect(node);
     }
 
     /**

--- a/src/effects/PitchEffect.js
+++ b/src/effects/PitchEffect.js
@@ -59,7 +59,7 @@ class PitchEffect {
     * @returns {number} a frequency ratio
     */
     intervalToFrequencyRatio (interval) {
-        return Math.pow(2, (interval/12));
+        return Math.pow(2, (interval / 12));
     }
 
     /**

--- a/src/effects/PitchEffect.js
+++ b/src/effects/PitchEffect.js
@@ -49,16 +49,8 @@ class PitchEffect {
     * @returns {number} a playback ratio
     */
     getRatio (val) {
-        return this.intervalToFrequencyRatio(val / 10);
-    }
-
-    /**
-    * Convert a musical interval to a frequency ratio.
-    * With thanks to Tone.js: https://github.com/Tonejs/Tone.js
-    * @param {number} interval - a musical interval, in semitones
-    * @returns {number} a frequency ratio
-    */
-    intervalToFrequencyRatio (interval) {
+        const interval = val / 10;
+        // Convert the musical interval in semitones to a frequency ratio
         return Math.pow(2, (interval / 12));
     }
 

--- a/src/effects/PitchEffect.js
+++ b/src/effects/PitchEffect.js
@@ -49,7 +49,7 @@ class PitchEffect {
     * @returns {number} a playback ratio
     */
     getRatio (val) {
-        return intervalToFrequencyRatio(val / 10);
+        return this.intervalToFrequencyRatio(val / 10);
     }
 
     /**

--- a/src/effects/PitchEffect.js
+++ b/src/effects/PitchEffect.js
@@ -1,5 +1,3 @@
-const Tone = require('tone');
-
 /**
 * A pitch change effect, which changes the playback rate of the sound in order
 * to change its pitch: reducing the playback rate lowers the pitch, increasing the rate
@@ -21,7 +19,6 @@ class PitchEffect {
     constructor () {
         this.value = 0; // effect value
         this.ratio = 1; // the playback rate ratio
-        this.tone = new Tone();
     }
 
     /**
@@ -52,8 +49,18 @@ class PitchEffect {
     * @returns {number} a playback ratio
     */
     getRatio (val) {
-        return this.tone.intervalToFrequencyRatio(val / 10);
+        return intervalToFrequencyRatio(val / 10);
     }
+
+    /**
+    * Convert a musical interval to a frequency ratio.
+    * With thanks to Tone.js: https://github.com/Tonejs/Tone.js
+    * @param {number} interval - a musical interval, in semitones
+    * @returns {number} a frequency ratio
+    */
+    intervalToFrequencyRatio (interval) {
+        return Math.pow(2, (interval/12));
+    };
 
     /**
     * Update a sound player's playback rate using the current ratio for the effect

--- a/src/effects/PitchEffect.js
+++ b/src/effects/PitchEffect.js
@@ -60,7 +60,7 @@ class PitchEffect {
     */
     intervalToFrequencyRatio (interval) {
         return Math.pow(2, (interval/12));
-    };
+    }
 
     /**
     * Update a sound player's playback rate using the current ratio for the effect

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ class AudioPlayer {
         this.panEffect = new PanEffect(this.audioEngine.audioContext);
 
         // Chain the audio effects together
-        // effectsNode -> panEffect -> audioEngine.input -> destination (speakers)
+        // effectsNode -> panEffect -> audioEngine.input
         this.effectsNode = this.audioEngine.audioContext.createGain();
         this.effectsNode.connect(this.panEffect.panner);
         this.panEffect.connect(this.audioEngine.input);

--- a/src/index.js
+++ b/src/index.js
@@ -317,7 +317,7 @@ class AudioEngine {
             let rms = Math.sqrt(sum / this.micDataArray.length);
             // smooth the value, if it is descending
             if (this._lastValue) {
-                rms = Math.max(rms, this._lastValue * 0.5);
+                rms = Math.max(rms, this._lastValue * 0.6);
             }
             this._lastValue = rms;
 

--- a/src/index.js
+++ b/src/index.js
@@ -321,11 +321,14 @@ class AudioEngine {
             }
             this._lastValue = rms;
 
-            // scale it
-            // @todo figure out why this magic number is needed and remove it!
+            // Scale the measurement so it's more sensitive to quieter sounds
             rms *= 1.63;
-            // scale and round the output
-            return Math.round(Math.sqrt(rms) * 100);
+            rms = Math.sqrt(rms);
+            // Scale it up to 0-100 and round
+            rms = Math.round(rms * 100);
+            // Prevent it from going above 100
+            rms = Math.min(rms, 100);
+            return rms;
         }
 
         // if there is no microphone input, return -1

--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ class AudioPlayer {
  */
 class AudioEngine {
     constructor () {
-        var AudioContext = window.AudioContext || window.webkitAudioContext;
+        const AudioContext = window.AudioContext || window.webkitAudioContext;
         this.context = new AudioContext();
 
         this.input = this.context.createGain();
@@ -200,7 +200,7 @@ class AudioEngine {
         let loaderPromise = null;
 
         // Make a copy of the buffer because decoding detaches the original buffer
-        var bufferCopy = sound.data.buffer.slice(0);
+        const bufferCopy = sound.data.buffer.slice(0);
 
         switch (sound.format) {
         case '':
@@ -296,13 +296,14 @@ class AudioEngine {
         // the microphone has not been set up, try to connect to it
         if (!this.mic && !this.connectingToMic) {
             this.connectingToMic = true; // prevent multiple connection attempts
-            navigator.mediaDevices.getUserMedia({audio : true}).then(stream => {
+            navigator.mediaDevices.getUserMedia({audio: true}).then(stream => {
                 this.mic = this.context.createMediaStreamSource(stream);
                 this.analyser = this.context.createAnalyser();
                 this.mic.connect(this.analyser);
                 this.micDataArray = new Float32Array(this.analyser.fftSize);
-            }).catch(err => {
-                log.warn(err)
+            })
+            .catch(err => {
+                log.warn(err);
             });
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -292,7 +292,7 @@ class AudioEngine {
      * @return {number} loudness scaled 0 to 100
      */
     getLoudness () {
-        // the microphone has not been set up, try to connect to it
+        // The microphone has not been set up, so try to connect to it
         if (!this.mic && !this.connectingToMic) {
             this.connectingToMic = true; // prevent multiple connection attempts
             navigator.mediaDevices.getUserMedia({audio: true}).then(stream => {
@@ -306,7 +306,7 @@ class AudioEngine {
             });
         }
 
-        // if the microphone is set up and active, measure the loudness
+        // If the microphone is set up and active, measure the loudness
         if (this.mic && this.mic.mediaStream.active) {
             this.analyser.getFloatTimeDomainData(this.micDataArray);
             let sum = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,6 @@ class AudioEngine {
 
         // microphone, for measuring loudness, with a level meter analyzer
         this.mic = null;
-        this.micMeter = null;
     }
 
     /**


### PR DESCRIPTION
### Proposed changes

Remove our dependency on the library Tone.js

### Reason for changes

We have been using the amazing and wonderful [tone.js](https://github.com/Tonejs/Tone.js) library for prototyping the audio engine, but as per https://github.com/LLK/scratch-audio/issues/23 it is time to move away from it, since we are no longer using most of its functionality. 

In a couple of places I use code closely modeled after code from tone, and I made a note of it in the comments. 
