### PR TITLE
Use audio-context module for shared audiocontext

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/LLK/scratch-audio#readme",
   "devDependencies": {
+    "audio-context": "^1.0.1",
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.2",
     "babel-loader": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/LLK/scratch-audio#readme",
   "devDependencies": {
-    "audio-context": "^1.0.1",
+    "audio-context": "1.0.1",
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.2",
     "babel-loader": "^6.4.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 const log = require('./log');
 
+const AudioContext = require('audio-context');
+
 const PitchEffect = require('./effects/PitchEffect');
 const PanEffect = require('./effects/PanEffect');
 
@@ -149,7 +151,6 @@ class AudioPlayer {
  */
 class AudioEngine {
     constructor () {
-        const AudioContext = window.AudioContext || window.webkitAudioContext;
         this.audioContext = new AudioContext();
 
         this.input = this.audioContext.createGain();


### PR DESCRIPTION
### Proposed changes

To prevent creating multiple audio contexts (for example when switching languages), use a node module that creates a single shared AudioContext.

### Reason for changes

Resolves https://github.com/LLK/scratch-audio/issues/53