### PR TITLE
Fall back to the older callback API for decodeAudioData

### DIFF
--- a/src/DrumPlayer.js
+++ b/src/DrumPlayer.js
@@ -44,7 +44,20 @@ class DrumPlayer {
             request.responseType = 'arraybuffer';
             request.onload = () => {
                 const audioData = request.response;
-                this.audioContext.decodeAudioData(audioData).then(buffer => {
+                // Check for newer promise-based API
+                let loaderPromise;
+                if (this.audioContext.decodeAudioData.length === 1) {
+                    loaderPromise = this.audioContext.decodeAudioData(audioData);
+                } else {
+                    // Fall back to callback API
+                    loaderPromise = new Promise((resolve, reject) => {
+                        this.audioContext.decodeAudioData(audioData,
+                            decodedAudio => resolve(decodedAudio),
+                            error => reject(error)
+                        );
+                    });
+                }
+                loaderPromise.then(buffer => {
                     this.drumSounds[i].setBuffer(buffer);
                 });
             };

--- a/src/index.js
+++ b/src/index.js
@@ -203,7 +203,18 @@ class AudioEngine {
 
         switch (sound.format) {
         case '':
-            loaderPromise = this.audioContext.decodeAudioData(bufferCopy);
+            // Check for newer promise-based API
+            if (this.audioContext.decodeAudioData.length === 1) {
+                loaderPromise = this.audioContext.decodeAudioData(bufferCopy);
+            } else {
+                // Fall back to callback API
+                loaderPromise = new Promise((resolve, reject) => {
+                    this.audioContext.decodeAudioData(bufferCopy,
+                        decodedAudio => resolve(decodedAudio),
+                        error => reject(error)
+                    );
+                });
+            }
             break;
         case 'adpcm':
             loaderPromise = (new ADPCMSoundDecoder(this.audioContext)).decode(bufferCopy);


### PR DESCRIPTION
### Proposed changes

Fall back to the older callback API for decodeAudioData. 

### Reason for changes

Safari does not support the newer Promise-based API for decodeAudioData.

Helps with the Safari-related issues such as https://github.com/LLK/scratch-gui/issues/542