### PR TITLE
Play sounds by unique sound ID and allow getting/setting buffers by sound ID

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -230,8 +230,8 @@ class AudioEngine {
      * @param {!string} soundId - the id of the sound buffer to get
      * @return {AudioBuffer} the buffer corresponding to the given sound id.
      */
-    getSoundBuffer (soundId, newBuffer) {
-        return this.audioBuffers[soundId] = newBuffer;
+    getSoundBuffer (soundId) {
+        return this.audioBuffers[soundId];
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -226,6 +226,24 @@ class AudioEngine {
     }
 
     /**
+     * Retrieve the audio buffer as held in memory for a given sound id.
+     * @param {!string} soundId - the id of the sound buffer to get
+     * @return {AudioBuffer} the buffer corresponding to the given sound id.
+     */
+    getSoundBuffer (soundId, newBuffer) {
+        return this.audioBuffers[soundId] = newBuffer;
+    }
+
+    /**
+     * Update the in-memory audio buffer to a new one by soundId.
+     * @param {!string} soundId - the id of the sound buffer to update.
+     * @param {AudioBuffer} newBuffer - the new buffer to swap in.
+     */
+    updateSoundBuffer (soundId, newBuffer) {
+        this.audioBuffers[soundId] = newBuffer;
+    }
+
+    /**
      * An older version of the AudioEngine had this function to load all sounds
      * This is a stub to provide a warning when it is called
      * @todo remove this

--- a/src/uid.js
+++ b/src/uid.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview UID generator, from Blockly.
+ */
+
+/**
+ * Legal characters for the unique ID.
+ * Should be all on a US keyboard.  No XML special characters or control codes.
+ * Removed $ due to issue 251.
+ * @private
+ */
+const soup_ = '!#%()*+,-./:;=?@[]^_`{|}~' +
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+/**
+ * Generate a unique ID, from Blockly.  This should be globally unique.
+ * 87 characters ^ 20 length > 128 bits (better than a UUID).
+ * @return {string} A globally unique ID string.
+ */
+const uid = function () {
+    const length = 20;
+    const soupLength = soup_.length;
+    const id = [];
+    for (let i = 0; i < length; i++) {
+        id[i] = soup_.charAt(Math.random() * soupLength);
+    }
+    return id.join('');
+};
+
+module.exports = uid;


### PR DESCRIPTION
### Proposed changes

_Describe what this Pull Request does_

Changes the `audioBuffers` object to use a unique id for each audio buffer instead of trusting/using the `md5` property. This allows each sound to be stored separately and edited without worrying about other sounds pointing at the same audio buffer.

This will require changes to the VM and to the GUI, which will reference this. 

The addition of `getSoundBuffer` and `updateSoundBuffer` are going to be used by the VM to organize sound updates from the editor. 

### Reason for changes

_Explain why these changes should be made. Please include an issue # if applicable._

Because the audio engine trusts the `md5` property of passed in sounds, we cannot safely update sound buffers when editing. 