### PR TITLE
Use StartAudioContext to allow playing on mobile safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "json": "^9.0.6",
     "minilog": "^3.0.1",
     "soundfont-player": "0.10.5",
+    "startaudiocontext": "1.2.1",
     "travis-after-all": "^1.4.4",
     "webpack": "2.4.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const StartAudioContext = require('startaudiocontext');
 const AudioContext = require('audio-context');
 
 const log = require('./log');
@@ -153,6 +154,7 @@ class AudioPlayer {
 class AudioEngine {
     constructor () {
         this.audioContext = new AudioContext();
+        StartAudioContext(this.audioContext);
 
         this.input = this.audioContext.createGain();
         this.input.connect(this.audioContext.destination);


### PR DESCRIPTION
### Proposed changes

_Describe what this Pull Request does_

Use the [StartAudioContext](https://github.com/tambien/StartAudioContext) module to get around mobile safari restrictions on using the web audio api without explicit user interaction. 

While this does bind itself to the `document` object, this module is never intended to be used outside of the `document`, so I think it is ok to assume we are in a browser. 

### Reason for changes

_Explain why these changes should be made. Please include an issue # if applicable._

Fixes https://github.com/LLK/scratch-audio/issues/24

Tested on iPad safari, play note blocks all work!