### PR TITLE
Safely stop sounds in safari

### DIFF
--- a/src/SoundPlayer.js
+++ b/src/SoundPlayer.js
@@ -48,7 +48,7 @@ class SoundPlayer {
      * Stop the sound
      */
     stop () {
-        if (this.bufferSource) {
+        if (this.bufferSource && this.isPlaying) {
             this.bufferSource.stop();
         }
         this.isPlaying = false;


### PR DESCRIPTION
### Proposed changes

Check the isPlaying flag before stopping a sound.

### Reason for changes

Fixes https://github.com/LLK/scratch-audio/issues/59