### PR TITLE
Add a function to get an AudioPlayer’s input node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,14 @@ class AudioPlayer {
     }
 
     /**
+     * Get this sprite's input node, so that other objects can route sound through it.
+     * @return {AudioNode} the AudioNode for this sprite's input
+     */
+    getInputNode () {
+        return this.effectsNode;
+    }
+
+    /**
      * Play a sound
      * @param  {string} soundId - the soundId id of a sound file
      * @return {Promise} a Promise that resolves when the sound finishes playing


### PR DESCRIPTION
### Proposed changes

Add a function to get a reference to the input node for an AudioPlayer. 

### Reason for changes

Each sprite has an AudioPlayer, which handles sounds played using the "play sound" block, and routes them through its effects chain, which includes the volume and pan settings. This function allows other sound sources to route sounds through this effects chain. I'm currently working on the music extension, which uses this function to route drum and instrument sounds through the effects for the sprite playing them. 