### PR TITLE
Don't use mediaStream property, which is missing on Firefox

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -263,6 +263,7 @@ class AudioEngine {
         if (!this.mic && !this.connectingToMic) {
             this.connectingToMic = true; // prevent multiple connection attempts
             navigator.mediaDevices.getUserMedia({audio: true}).then(stream => {
+                this.audioStream = stream;
                 this.mic = this.audioContext.createMediaStreamSource(stream);
                 this.analyser = this.audioContext.createAnalyser();
                 this.mic.connect(this.analyser);
@@ -274,7 +275,7 @@ class AudioEngine {
         }
 
         // If the microphone is set up and active, measure the loudness
-        if (this.mic && this.mic.mediaStream.active) {
+        if (this.mic && this.audioStream.active) {
             this.analyser.getFloatTimeDomainData(this.micDataArray);
             let sum = 0;
             // compute the RMS of the sound


### PR DESCRIPTION
### Proposed changes

Avoids referencing the `mediaStream` property, which, while part of the WebAudio spec, is not implemented in Firefox. `mediaStream` is just a reference to the stream which `this.mic` was created with, so we store it separately in an `audioStream` property and reference that instead.

This is *not* tested; I'm not sure how to get a test setup working. I recall testing an identical change on a basic WebAudio demo page, though, and it worked fine there.

### Reason for changes

Fixes #67 and LLK/scratch-vm#796; makes the "loudness" Scratch block work in Firefox.

(For what it's relevant, it looks like LLK/scratch-vm#305 should also be closed; loudness detection *is* implemented, including returning -1 for no microphone.)