### PR TITLE
Disconnect audio nodes on dispose

### DIFF
--- a/src/effects/PanEffect.js
+++ b/src/effects/PanEffect.js
@@ -52,6 +52,16 @@ class PanEffect {
     connect (node) {
         this.channelMerger.connect(node);
     }
+
+    /**
+     * Clean up and disconnect audio nodes.
+     */
+    dispose () {
+        this.input.disconnect();
+        this.leftGain.disconnect();
+        this.rightGain.disconnect();
+        this.channelMerger.disconnect();
+    }
 }
 
 module.exports = PanEffect;

--- a/src/index.js
+++ b/src/index.js
@@ -133,6 +133,14 @@ class AudioPlayer {
         if (this.audioEngine === null) return;
         this.effectsNode.gain.setTargetAtTime(value / 100, 0, this.audioEngine.DECAY_TIME);
     }
+
+    /**
+     * Clean up and disconnect audio nodes.
+     */
+    dispose () {
+        this.panEffect.dispose();
+        this.effectsNode.disconnect();
+    }
 }
 
 


### PR DESCRIPTION
### Proposed changes

Disconnect an AudioPlayer's audio nodes from the web audio graph using a dispose function. This includes the effectsNode gain node and the nodes used by the pan effect.  

### Reason for changes

When a sprite or clone is deleted, if its AudioPlayer's audio nodes are not explicitly disconnected, they are apparently not cleaned up by garbage collection. This seems to be the cause of the audio context completely ceasing to produce sound after a large number of clones have been created and deleted. 

With this dispose function (called in the VM in an upcoming PR), we can safely create and delete large numbers of clones and the sound continues to work.
