### PR TITLE
add and use VolumeEffect in AudioPlayer

### DIFF
--- a/src/AudioPlayer.js
+++ b/src/AudioPlayer.js
@@ -142,6 +142,7 @@ class AudioPlayer {
      * @param {object} target - target whose node to should be connected
      */
     connect (target) {
+        this.outputNode.disconnect();
         this.outputNode.connect(target.getInputNode());
     }
 

--- a/src/AudioPlayer.js
+++ b/src/AudioPlayer.js
@@ -1,5 +1,6 @@
-const PitchEffect = require('./effects/PitchEffect');
 const PanEffect = require('./effects/PanEffect');
+const PitchEffect = require('./effects/PitchEffect');
+const VolumeEffect = require('./effects/VolumeEffect');
 
 const SoundPlayer = require('./SoundPlayer');
 
@@ -17,9 +18,11 @@ class AudioPlayer {
         this.outputNode = this.audioEngine.audioContext.createGain();
 
         // Create the audio effects
-        const pitchEffect = new PitchEffect(this.audioEngine, this, null);
+        const volumeEffect = new VolumeEffect(this.audioEngine, this, null);
+        const pitchEffect = new PitchEffect(this.audioEngine, this, volumeEffect);
         const panEffect = new PanEffect(this.audioEngine, this, pitchEffect);
         this.effects = {
+            volume: volumeEffect,
             pitch: pitchEffect,
             pan: panEffect
         };
@@ -28,6 +31,7 @@ class AudioPlayer {
         // outputNode -> "pitchEffect" -> panEffect -> audioEngine.input
         panEffect.connect(this.audioEngine);
         pitchEffect.connect(panEffect);
+        volumeEffect.connect(pitchEffect);
 
         // reset effects to their default parameters
         this.clearEffects();
@@ -123,9 +127,6 @@ class AudioPlayer {
         for (const effectName in this.effects) {
             this.effects[effectName].clear();
         }
-
-        if (this.audioEngine === null) return;
-        this.outputNode.gain.setTargetAtTime(1.0, 0, this.audioEngine.DECAY_TIME);
     }
 
     /**
@@ -133,8 +134,7 @@ class AudioPlayer {
      * @param {number} value - the volume in range 0-100
      */
     setVolume (value) {
-        if (this.audioEngine === null) return;
-        this.outputNode.gain.setTargetAtTime(value / 100, 0, this.audioEngine.DECAY_TIME);
+        this.setEffect('volume', value);
     }
 
     /**
@@ -150,6 +150,7 @@ class AudioPlayer {
      * Clean up and disconnect audio nodes.
      */
     dispose () {
+        this.effects.volume.dispose();
         this.effects.pitch.dispose();
         this.effects.pan.dispose();
 

--- a/src/effects/Effect.js
+++ b/src/effects/Effect.js
@@ -38,7 +38,7 @@ class Effect {
      * @return {boolean} is the effect affecting the graph?
      */
     get _isPatch () {
-        return this.initialized;
+        return this.initialized && this.value !== this.DEFAULT_VALUE;
     }
 
     /**
@@ -46,7 +46,7 @@ class Effect {
      * @return {AudioNode} - audio node that is the input for this effect
      */
     getInputNode () {
-        if (this.initialized) {
+        if (this._isPatch) {
             return this.inputNode;
         }
         return this.target.getInputNode();
@@ -115,6 +115,10 @@ class Effect {
 
         if (target === null) {
             return;
+        }
+
+        if (this.outputNode !== null) {
+            this.outputNode.disconnect();
         }
 
         let nextTarget = target;

--- a/src/effects/PanEffect.js
+++ b/src/effects/PanEffect.js
@@ -21,14 +21,6 @@ class PanEffect extends Effect {
     }
 
     /**
-     * Should the effect be connected to the audio graph?
-     * @return {boolean} is the effect affecting the graph?
-     */
-    get _isPatch () {
-        return this.initialized && this.value !== 0;
-    }
-
-    /**
      * Initialize the Effect.
      * Effects start out uninitialized. Then initialize when they are first set
      * with some value.

--- a/src/effects/VolumeEffect.js
+++ b/src/effects/VolumeEffect.js
@@ -1,0 +1,54 @@
+const Effect = require('./Effect');
+
+/**
+ * Affect the volume of an effect chain.
+ */
+class VolumeEffect extends Effect {
+    /**
+     * Default value to set the Effect to when constructed and when clear'ed.
+     * @const {number}
+     */
+    get DEFAULT_VALUE () {
+        return 100;
+    }
+
+    /**
+     * Initialize the Effect.
+     * Effects start out uninitialized. Then initialize when they are first set
+     * with some value.
+     * @throws {Error} throws when left unimplemented
+     */
+    initialize () {
+        this.inputNode = this.audioEngine.audioContext.createGain();
+        this.outputNode = this.inputNode;
+
+        this.initialized = true;
+    }
+
+    /**
+     * Set the effects value.
+     * @private
+     * @param {number} value - new value to set effect to
+     */
+    _set (value) {
+        this.value = value;
+        // A gain of 1 is normal. Scale down scratch's volume value. Apply the
+        // change over a tiny period of time.
+        this.outputNode.gain.setTargetAtTime(value / 100, 0, this.audioEngine.DECAY_TIME);
+    }
+
+    /**
+     * Clean up and disconnect audio nodes.
+     */
+    dispose () {
+        this.outputNode.disconnect();
+
+        this.inputNode = null;
+        this.outputNode = null;
+        this.target = null;
+
+        this.initialized = false;
+    }
+}
+
+module.exports = VolumeEffect;


### PR DESCRIPTION
### Proposed changes

Add a VolumeEffect and use it in AudioPlayer.

### Reason for changes

This effects removes volume's specialization in AudioPlayer.

This will help in making stopping sounds fade out as we can make extra VolumeEffects to manage that extra gain node.
