### PR TITLE
Don't use npm prepublish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,14 @@ jobs:
     node_js: 8
   - stage: release
     node_js: 8
-    script: skip
+    env: NPM_SCRIPT=build
     before_deploy:
     - npm --no-git-tag-version version 0.1.0-prerelease.$(date +%Y%m%d%H%M%S)
     deploy:
     - provider: npm
       on:
         all_branches: true
+      skip_cleanup: true
       email: $NPM_EMAIL
       api_key: $NPM_TOKEN
 stages:

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "build": "webpack --bail",
     "watch": "webpack --watch",
     "lint": "eslint .",
-    "tap": "tap test/effects/*.js test/*.js",
-    "prepublish": "npm run build"
+    "tap": "tap test/effects/*.js test/*.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Be explicit and build on the release step. This way it doesn't matter which version of npm we use (since prepublish is deprecated in npm 5). Also because we don't actually need to build to use scratch-audio in scratch-gui, so it doesn't help to run build on npm install anyway.
