### PR TITLE
Bump wcli

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "tap": "^12.0.1",
     "web-audio-test-api": "^0.5.2",
     "webpack": "^4.8.0",
-    "webpack-cli": "^2.0.15"
+    "webpack-cli": "^3.1.2"
   }
 }


### PR DESCRIPTION
### Proposed changes

Bump webpack-cli.

### Reason for changes

Most of the repos have had their webpack-cli dependency bumped to workaround a bug in an older version of webpack-cli dependencies in yargs that keeps travis from working.
