### PR TITLE
Handle empty and unusually formatted sounds that caused crashes

### DIFF
--- a/src/ArrayBufferStream.js
+++ b/src/ArrayBufferStream.js
@@ -150,7 +150,6 @@ class ArrayBufferStream {
      * @return {number} the next 32 bit integer in the stream
      */
     readInt32 () {
-        // const sliced = this.arrayBuffer.slice
         let val;
         if (this._position % 4 === 0) {
             val = new Int32Array(this.arrayBuffer, this._position, 1)[0];

--- a/src/ArrayBufferStream.js
+++ b/src/ArrayBufferStream.js
@@ -150,7 +150,17 @@ class ArrayBufferStream {
      * @return {number} the next 32 bit integer in the stream
      */
     readInt32 () {
-        const val = new Int32Array(this.arrayBuffer, this._position, 1)[0];
+        // const sliced = this.arrayBuffer.slice
+        let val;
+        if (this._position % 4 === 0) {
+            val = new Int32Array(this.arrayBuffer, this._position, 1)[0];
+        } else {
+            // Cannot read Int32 directly out because offset is not multiple of 4
+            // Need to slice out the values first
+            val = new Int32Array(
+                this.arrayBuffer.slice(this._position, this._position + 4)
+            )[0];
+        }
         this._position += 4; // one 32 bit int is 4 bytes
         return val;
     }

--- a/src/AudioEngine.js
+++ b/src/AudioEngine.js
@@ -154,6 +154,11 @@ class AudioEngine {
         // decoder If that fails, attempt to decode as ADPCM
         const decoding = decodeAudioData(this.audioContext, bufferCopy1)
             .catch(() => {
+                // If the file is empty, create an empty sound
+                if (sound.data.length === 0) {
+                    return Promise.resolve(this.audioContext.createBuffer(1, 1, this.audioContext.sampleRate));
+                }
+
                 // The audio context failed to parse the sound data
                 // we gave it, so try to decode as 'adpcm'
 


### PR DESCRIPTION
### Proposed changes

- Sounds with zero length were causing a crash. Create an empty but otherwise well formatted sound for the VM to load.
- Sounds containing an unusual header (ADPCM waves with a LIST chunk with a length that is not a multiple of 4), were causing a crash. In that case, slice the arrayBuffer first rather than trying to use a non-multiple-of-4 offset.

### Reason for changes

Prevent some crashes! 

Empty sound crash:
https://scratch.mit.edu/projects/192455743/

Weird header crash (CSFirst projects):
https://scratch.mit.edu/projects/58168422/ 
https://scratch.mit.edu/projects/46414930/ 

cc @mzgoddard 


