### PR TITLE
Catch ADPCM decode error, and use an empty sound

### DIFF
--- a/src/AudioEngine.js
+++ b/src/AudioEngine.js
@@ -156,7 +156,7 @@ class AudioEngine {
             .catch(() => {
                 // If the file is empty, create an empty sound
                 if (sound.data.length === 0) {
-                    return Promise.resolve(this.audioContext.createBuffer(1, 1, this.audioContext.sampleRate));
+                    return Promise.resolve(this._emptySound());
                 }
 
                 // The audio context failed to parse the sound data
@@ -165,7 +165,8 @@ class AudioEngine {
                 // First we need to create another copy of our original data
                 const bufferCopy2 = sound.data.buffer.slice(0);
                 // Try decoding as adpcm
-                return new ADPCMSoundDecoder(this.audioContext).decode(bufferCopy2);
+                return new ADPCMSoundDecoder(this.audioContext).decode(bufferCopy2)
+                    .catch(() => Promise.resolve(this._emptySound()));
             })
             .then(
                 buffer => ([soundId, buffer]),
@@ -175,6 +176,14 @@ class AudioEngine {
             );
 
         return decoding;
+    }
+
+    /**
+     * An empty sound buffer, for use when we are unable to decode a sound file.
+     * @returns {AudioBuffer} - an empty audio buffer.
+     */
+    _emptySound () {
+        return this.audioContext.createBuffer(1, 1, this.audioContext.sampleRate);
     }
 
     /**

--- a/src/AudioEngine.js
+++ b/src/AudioEngine.js
@@ -156,7 +156,7 @@ class AudioEngine {
             .catch(() => {
                 // If the file is empty, create an empty sound
                 if (sound.data.length === 0) {
-                    return Promise.resolve(this._emptySound());
+                    return this._emptySound();
                 }
 
                 // The audio context failed to parse the sound data
@@ -166,7 +166,7 @@ class AudioEngine {
                 const bufferCopy2 = sound.data.buffer.slice(0);
                 // Try decoding as adpcm
                 return new ADPCMSoundDecoder(this.audioContext).decode(bufferCopy2)
-                    .catch(() => Promise.resolve(this._emptySound()));
+                    .catch(() => this._emptySound());
             })
             .then(
                 buffer => ([soundId, buffer]),


### PR DESCRIPTION
### Proposed changes

If the ADPCM decoder fails with an error, catch it and return an empty audio buffer.

### Reason for changes

Prevent BSOD for projects with sounds that Scratch is unable to decode.

Test with project 256450219

This project would previously BSOD, but with this change several sounds load empty instead (in the first sprite, "bendy", the sounds "song that might play when you fight sans", "harry potter theme" and "Sans and Papyrus Song", etc.). The actual assets are playable wave files, but in Scratch 2.0, these sounds also loaded empty, so this behavior is the same.
 
