### PR TITLE
Don't setValueAtTime in volume effect

### DIFF
--- a/src/SoundPlayer.js
+++ b/src/SoundPlayer.js
@@ -299,8 +299,8 @@ class SoundPlayer extends EventEmitter {
         taken.finished().then(() => taken.dispose());
 
         taken.volumeEffect.set(0);
-        const {currentTime, DECAY_WAIT, DECAY_DURATION} = this.audioEngine;
-        taken.outputNode.stop(currentTime + DECAY_WAIT + DECAY_DURATION);
+        const {currentTime, DECAY_DURATION} = this.audioEngine;
+        taken.outputNode.stop(currentTime + DECAY_DURATION);
     }
 
     /**

--- a/src/effects/VolumeEffect.js
+++ b/src/effects/VolumeEffect.js
@@ -43,7 +43,6 @@ class VolumeEffect extends Effect {
 
         const {gain} = this.outputNode;
         const {currentTime, DECAY_WAIT, DECAY_DURATION} = this.audioEngine;
-        gain.setValueAtTime(gain.value, currentTime + DECAY_WAIT);
         gain.linearRampToValueAtTime(value / 100, currentTime + DECAY_WAIT + DECAY_DURATION);
     }
 

--- a/src/effects/VolumeEffect.js
+++ b/src/effects/VolumeEffect.js
@@ -42,8 +42,8 @@ class VolumeEffect extends Effect {
         this.value = value;
 
         const {gain} = this.outputNode;
-        const {currentTime, DECAY_WAIT, DECAY_DURATION} = this.audioEngine;
-        gain.linearRampToValueAtTime(value / 100, currentTime + DECAY_WAIT + DECAY_DURATION);
+        const {currentTime, DECAY_DURATION} = this.audioEngine;
+        gain.linearRampToValueAtTime(value / 100, currentTime + DECAY_DURATION);
     }
 
     /**

--- a/test/SoundPlayer.js
+++ b/test/SoundPlayer.js
@@ -71,7 +71,7 @@ tap.test('SoundPlayer', suite => {
     });
 
     suite.test('stop decay', t => {
-        t.plan(7);
+        t.plan(5);
         soundPlayer.play();
         soundPlayer.connect(audioEngine);
         const outputNode = soundPlayer.outputNode;
@@ -88,13 +88,10 @@ tap.test('SoundPlayer', suite => {
             inputs: [outputNode.toJSON()]
         }], 'output node connects to gain node to input node');
 
-        audioContext.$processTo(audioEngine.DECAY_WAIT + audioEngine.DECAY_DURATION / 2);
-        const engineInputs = help.engineInputs;
-        t.notEqual(engineInputs[0].gain.value, 1, 'gain value should not be 1');
-        t.notEqual(engineInputs[0].gain.value, 0, 'gain value should not be 0');
+        audioContext.$processTo(audioEngine.DECAY_DURATION / 2);
         t.equal(outputNode.$state, 'PLAYING');
 
-        audioContext.$processTo(audioEngine.DECAY_WAIT + audioEngine.DECAY_DURATION + 0.001);
+        audioContext.$processTo(audioEngine.DECAY_DURATION + 0.001);
         t.deepEqual(help.engineInputs, [{
             name: 'GainNode',
             gain: {


### PR DESCRIPTION
### Resolves

Resolves #111, resolves #116, and resolves #117 

### Proposed changes

This PR removes the VolumeEffect's setValueAtTime call on its gain node when its volume is set.

### Reason for changes

For bizarre reasons which I believe relate to automation ("ramp to value at time", etc.), the `GainNode`'s 
gain `value` always == 1 when we read it. This resulted in the volume ramping down from 100% whenever it was set, causing a spike in loudness.